### PR TITLE
サーバープロセスとの入出力を疑似端末で実装する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 /config/
 /plugins/
+/test/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Minecraft Java サーバー 管理システム |
 ## 環境
 - Python 3.10
 - Linux (推奨)
-- Windows (一部の機能は非対応)
+- Windows
 
 ※ macOSは未確認。おそらく動作？
 

--- a/README.md
+++ b/README.md
@@ -69,5 +69,17 @@ REST API は初期設定で [`http://0.0.0.0:8080/docs`](http://localhost:8080/d
 ## WebSocket
 WebSocket クライアントを `http://0.0.0.0:8080/ws` に接続することで、サーバーイベント等を JSON フォーマットで受信できます。
 
+### WS 受信
 > [craftswitcher.py](dncore%2Fextensions%2Fcraftswitcher%2Fcraftswitcher.py)<br>
 > `# events ws broadcast` このコマンド行の以下に実装があります
+
+
+### WS 送信
+> サーバープロセスへのテキストの書き込み
+> ```json
+> {
+>   "type": "server_process_write",
+>   "server": "lobby",
+>   "data": "say Hello\r\n"
+> }
+> ```

--- a/dncore/extensions/craftswitcher/craftswitcher.py
+++ b/dncore/extensions/craftswitcher/craftswitcher.py
@@ -480,6 +480,16 @@ class CraftSwitcher(EventListener):
         )
         await self.api_handler.broadcast_websocket(event_data)
 
+    @onevent(monitor=True)
+    async def _ws_on_server_process_read(self, event: ServerProcessReadEvent):
+        event_data = dict(
+            type="event",
+            event_type="server_process_read",
+            server=event.server.id,
+            data=event.data
+        )
+        await self.api_handler.broadcast_websocket(event_data)
+
 
 def getinst() -> "CraftSwitcher":
     try:

--- a/dncore/extensions/craftswitcher/event.py
+++ b/dncore/extensions/craftswitcher/event.py
@@ -13,6 +13,7 @@ __all__ = [
     "ServerLaunchOptionBuildEvent",
     "ServerCreatedEvent",
     "ServerDeletedEvent",
+    "ServerProcessReadEvent",
     "SwitcherInitializedEvent",
     "SwitcherShutdownEvent",
     "SwitcherConfigLoadedEvent",
@@ -64,6 +65,12 @@ class ServerCreatedEvent(Event, ServerEvent):
 
 class ServerDeletedEvent(Event, ServerEvent):
     pass
+
+
+class ServerProcessReadEvent(Event, ServerEvent):
+    def __init__(self, server: "ServerProcess", data: str):
+        super().__init__(server)
+        self.data = data
 
 
 class SwitcherInitializedEvent(Event):

--- a/dncore/extensions/craftswitcher/plugin.yml
+++ b/dncore/extensions/craftswitcher/plugin.yml
@@ -16,3 +16,4 @@ libraries:
   - aiosqlite
   - passlib
   - bcrypt
+  - pywinpty; sys_platform == "win32"

--- a/dncore/extensions/craftswitcher/publicapi/handler.py
+++ b/dncore/extensions/craftswitcher/publicapi/handler.py
@@ -124,8 +124,30 @@ class APIHandler(object):
             self._websocket_clients.add(client)
 
             try:
-                async for data in websocket.iter_json():  # TODO: handle data
-                    log.debug("WS#%s -> %s", client.id, data)
+                async for data in websocket.iter_json():
+                    log.debug("WS#%s -> %s", client.id, data)  # TODO: remove debug
+
+                    try:
+                        request_type = data["type"]
+                    except KeyError:
+                        continue
+
+                    if request_type == "server_process_write":
+                        try:
+                            server_id = data["server"]
+                            write_data = data["data"]
+                        except KeyError:
+                            continue
+
+                        try:
+                            server = inst.servers[server_id]
+                        except KeyError:
+                            continue
+                        if server and server.state.is_running:
+                            try:
+                                server.wrapper.write(write_data)
+                            except Exception as e:
+                                server.log.warning("Exception in write to server process by WS#%s", client.id, exc_info=e)
 
             finally:
                 self._websocket_clients.discard(client)

--- a/dncore/extensions/craftswitcher/serverprocess.py
+++ b/dncore/extensions/craftswitcher/serverprocess.py
@@ -20,31 +20,6 @@ from .utils import *
 _log = logging.getLogger(__name__)
 
 
-# noinspection PyMethodMayBeStatic
-class ProcessReader:
-    def subprocess_args(self, **kwargs) -> dict[str, Any]:
-        raise NotImplemented
-
-    async def loop_read(self, process: subprocess.Process):
-        raise NotImplemented
-
-
-class TextProcessReader(ProcessReader):
-    def subprocess_args(self, **kwargs) -> dict[str, Any]:
-        return dict(
-            kwargs,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-
-    async def loop_read(self, process: subprocess.Process):
-        reader = process.stdout
-        while line := await reader.readline():
-            line = line.rstrip()
-            _log.info(f"[OUTPUT] %s", line.decode("utf-8"))
-
-
 class ServerProcess(object):
     class Config:
         class LaunchOption:
@@ -165,21 +140,15 @@ class ServerProcess(object):
         self._config = config
         self.config = ServerProcess.Config(config, global_config)
 
-        self.process_reader_type = TextProcessReader  # type: Callable[[], ProcessReader]
+        self.wrapper = None  # type: ProcessWrapper | None
         self._state = ServerState.STOPPED
-        self._process = None  # type: subprocess.Process | None
         self._perf_mon = None  # type: ProcessPerformanceMonitor | None
-        self._process_read_loop_task = None  # type: asyncio.Task | None
         #
         self.shutdown_to_restart = False
 
     @property
-    def process(self):
-        return self._process
-
-    @property
     def _is_running(self):
-        return self.process and self.process.returncode is None
+        return self.wrapper and self.wrapper.exit_status is None
 
     @property
     def state(self):
@@ -222,13 +191,8 @@ class ServerProcess(object):
         self.log.debug(f"Memory check -> Available:{round(mem_available, 1):,}MB, Require:{round(required, 1):,}MB")
         return mem_available > required
 
-    async def _process_read_loop(self, process: subprocess.Process, reader: ProcessReader):
-        try:
-            await reader.loop_read(process)
-        finally:
-            ret = await process.wait()
-            self.log.info("Stopped server process (ret: %s)", ret)
-            self.state = ServerState.STOPPED
+    async def _term_read(self, data: str):
+        self.log.info(f"[OUTPUT]: {data.lstrip()!r}")
 
     async def _build_arguments(self):
         generated_arguments = False
@@ -255,40 +219,42 @@ class ServerProcess(object):
         _event = await call_event(ServerLaunchOptionBuildEvent(self, args, is_generated=generated_arguments))
         return _event.args
 
-    async def _start_subprocess(self, args: list[str], reader: ProcessReader):
-        return await subprocess.create_subprocess_exec(
-            args[0], *args[1:], **reader.subprocess_args(
-                cwd=self.directory,
-                start_new_session=True,
-            )
+    # noinspection PyMethodMayBeStatic
+    async def _start_subprocess(
+            self, args: list[str], term_size: tuple[int, int],
+            *, read_handler: Callable[[str], Awaitable[None]],
+    ):
+        return await PtyProcessWrapper.spawn(
+            args=args,
+            cwd=self.directory,
+            term_size=term_size,
+            read_handler=read_handler,
         )
 
     async def start(self):
         if self._is_running:
             raise errors.AlreadyRunningError
 
-        if self._process_read_loop_task and not self._process_read_loop_task.done():
-            try:
-                await self._process_read_loop_task
-            except (Exception,):
-                pass
-
         self.log.info(f"Starting {self.id} server process")
         _event = await call_event(ServerPreStartEvent(self))
         if _event.cancelled:
             raise errors.OperationCancelledError(_event.cancelled_reason or "Unknown Reason")
+
+        def _end(_):
+            ret_ = wrapper.exit_status
+            self.log.info("Stopped server process (ret: %s)", ret_)
+            self.state = ServerState.STOPPED
 
         try:
             if not self.check_free_memory():
                 raise errors.OutOfMemoryError
 
             args = await self._build_arguments()
-            reader = self.process_reader_type()
-            p = self._process = await self._start_subprocess(args, reader)
 
-            self._process_read_loop_task = self.loop.create_task(self._process_read_loop(p, reader))
+            wrapper = self.wrapper = await self._start_subprocess(args, term_size=(80, 25), read_handler=self._term_read)
+            self.loop.create_task(wrapper.wait()).add_done_callback(_end)
             try:
-                await asyncio.wait_for(p.wait(), timeout=1)
+                await asyncio.wait_for(wrapper.wait(), timeout=1)
             except asyncio.TimeoutError:
                 pass
 
@@ -296,15 +262,16 @@ class ServerProcess(object):
             self.log.exception("Exception in pre start", exc_info=e)
             raise errors.ServerLaunchError from e
 
-        if p.returncode is None:
+        ret = wrapper.exit_status
+        if ret is None:
             self.state = ServerState.RUNNING
 
         else:
-            self.log.warning("Exited process: return code: %s", p.returncode)
-            raise errors.ServerLaunchError(f"Failed to launch: process exited {p.returncode}")
+            self.log.warning("Exited process: return code: %s", ret)
+            raise errors.ServerLaunchError(f"Failed to launch: process exited {ret}")
 
         try:
-            self._perf_mon = ProcessPerformanceMonitor(p.pid)
+            self._perf_mon = ProcessPerformanceMonitor(wrapper.pid)
         except Exception as e:
             self.log.warning("Exception in init perf.mon", exc_info=e)
 
@@ -335,7 +302,7 @@ class ServerProcess(object):
             raise errors.NotRunningError
 
         self.log.info(f"Killing {self.id} server process...")
-        self._process.send_signal(signal.SIGKILL)
+        self.wrapper.kill(signal.SIGKILL)
 
     async def wait_for_shutdown(self, *, timeout: int = None):
         if timeout is None:

--- a/dncore/extensions/craftswitcher/serverprocess.py
+++ b/dncore/extensions/craftswitcher/serverprocess.py
@@ -193,7 +193,11 @@ class ServerProcess(object):
         return mem_available > required
 
     async def _term_read(self, data: str):
-        self.log.info(f"[OUTPUT]: {data.lstrip()!r}")
+        data = data.lstrip()
+        self.log.info(f"[OUTPUT]: {data!r}")
+
+        if data:
+            call_event(ServerProcessReadEvent(self, data))  # イベント負荷を要検証
 
     async def _build_arguments(self):
         generated_arguments = False

--- a/dncore/extensions/craftswitcher/serverprocess.py
+++ b/dncore/extensions/craftswitcher/serverprocess.py
@@ -472,7 +472,7 @@ else:
             try:
                 p = await asyncio.create_subprocess_exec(
                     *args,
-                    stdin=slave, stdout=slave, stderr=slave, close_fds=True,
+                    stdin=slave, stdout=slave, stderr=slave, cwd=cwd, close_fds=True,
                 )
             except Exception as e:
                 raise RuntimeError("Unable to create_subprocess_exec") from e
@@ -494,9 +494,12 @@ else:
             _decode = bytes.decode
 
             try:
-                while data := os_read(fd, 1024 * 8):
+                while True:
+                    try:
+                        data = os_read(fd, 1024 * 8)
+                    except OSError:
+                        break
                     queue_put(_decode(data, "utf-8", errors="ignore"))
-                queue_put("")
             except Exception as e:
                 _log.exception("Exception in os.read", exc_info=e)
             finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sqlalchemy
 aiosqlite
 passlib
 bcrypt
+pywinpty; sys_platform == "win32"


### PR DESCRIPTION
Unix では Python 標準の pty を使い、Windows では pywinpty ライブラリを使用して実装します。

端末から送られるデータはDNCイベント(*)を介し、接続されたWebSocketにキャストします。
逆に、WebSocketから内容を送れば、サーバープロセスの端末に送信できます。

Windows でもタブコンプリートできることを確認済み。


\* 頻繁に実行される処理にDNCイベントを使うべきではない可能性がある